### PR TITLE
Changed OrientJdbcDatabaseMetaData to make possible to grab all columns definition

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,12 @@
             <timezone>+1</timezone>
         </developer>
     </developers>
+    <contributors>
+        <contributor>
+            <name>Marvin Froeder</name>
+            <email>velo dot br at gmail dot com</email>
+        </contributor>
+    </contributors>
 
     <scm>
         <connection>scm:git:git@github.com:orientechnologies/orientdb-jdbc.git</connection>

--- a/src/main/java/com/orientechnologies/orient/jdbc/OrientJdbcDatabaseMetaData.java
+++ b/src/main/java/com/orientechnologies/orient/jdbc/OrientJdbcDatabaseMetaData.java
@@ -133,16 +133,26 @@ public class OrientJdbcDatabaseMetaData implements DatabaseMetaData {
 
     final OClass clazz = database.getMetadata().getSchema().getClass(tableNamePattern);
     if (clazz != null) {
-      final OProperty prop = clazz.getProperty(columnNamePattern);
-      if (prop != null) {
-        records.add((ODocument) new ODocument().field("TABLE_CAT", database.getName()).field("TABLE_NAME", clazz.getName())
-            .field("COLUMN_NAME", prop.getName()).field("DATA_TYPE", OrientJdbcResultSetMetaData.getSqlType(prop.getType()))
-            .field("COLUMN_SIZE", 1).field("NULLABLE", !prop.isNotNull()).field("IS_NULLABLE", prop.isNotNull() ? "NO" : "YES"));
+      if (columnNamePattern == null) {
+        for (OProperty prop : clazz.properties()) {
+          records.add(getColumnRecord(prop, clazz));
+        }
+      } else {
+        final OProperty prop = clazz.getProperty(columnNamePattern);
+        if (prop != null) {
+          records.add(getColumnRecord(prop, clazz));
+        }
       }
     }
 
     return new OrientJdbcResultSet(new OrientJdbcStatement(connection), records, ResultSet.TYPE_FORWARD_ONLY,
         ResultSet.CONCUR_READ_ONLY, ResultSet.HOLD_CURSORS_OVER_COMMIT);
+  }
+
+  private ODocument getColumnRecord(OProperty prop, final OClass clazz) {
+    return (ODocument) new ODocument().field("TABLE_CAT", database.getName()).field("TABLE_NAME", clazz.getName())
+        .field("COLUMN_NAME", prop.getName()).field("DATA_TYPE", OrientJdbcResultSetMetaData.getSqlType(prop.getType()))
+        .field("COLUMN_SIZE", 1).field("NULLABLE", !prop.isNotNull()).field("IS_NULLABLE", prop.isNotNull() ? "NO" : "YES");
   }
 
   public Connection getConnection() throws SQLException {

--- a/src/test/java/com/orientechnologies/orient/jdbc/OrientJdbcDatabaseMetaDataTest.java
+++ b/src/test/java/com/orientechnologies/orient/jdbc/OrientJdbcDatabaseMetaDataTest.java
@@ -1,6 +1,7 @@
 package com.orientechnologies.orient.jdbc;
 
 import com.orientechnologies.orient.core.OConstants;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -15,6 +16,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -111,11 +115,22 @@ public class OrientJdbcDatabaseMetaDataTest extends OrientJdbcBaseTest {
   }
 
   @Test
+  public void getAllFields() throws SQLException {
+    ResultSet rsmc = conn.getMetaData().getColumns(null, null, "OUser", null);
+    List<String> fieldNames = new ArrayList<String>();
+    while (rsmc.next()) {
+      fieldNames.add(rsmc.getString("COLUMN_NAME"));
+    }
+
+    assertThat(fieldNames, containsInAnyOrder("name", "password", "roles", "status"));
+  }
+
+  @Test
   public void getAllTables() throws SQLException {
     ResultSet rs = this.metaData.getTables(null, null, null, null);
     int tableCount = 0;
 
-    while(rs.next()){
+    while (rs.next()) {
       tableCount = tableCount + 1;
     }
     assertTrue(tableCount > 1);
@@ -126,7 +141,7 @@ public class OrientJdbcDatabaseMetaDataTest extends OrientJdbcBaseTest {
     ResultSet rs = this.metaData.getTables(null, null, "ouser", null);
     int tableCount = 0;
 
-    while(rs.next()){
+    while (rs.next()) {
       tableCount = tableCount + 1;
     }
     assertEquals(1, tableCount);


### PR DESCRIPTION
Hi,

I'm using holidays to try out orient db, and while I was doing it I found that was not possible to grab all columns (like it is in postgres, mysql and other).

So I made a small fix for it, hopefully it is ok.