### PR TITLE
Add test for DELETE in executeUpdate()

### DIFF
--- a/src/test/java/com/orientechnologies/orient/jdbc/OrientJdbcPreparedStatementTest.java
+++ b/src/test/java/com/orientechnologies/orient/jdbc/OrientJdbcPreparedStatementTest.java
@@ -49,7 +49,7 @@ public class OrientJdbcPreparedStatementTest extends OrientJdbcBaseTest {
 		conn.createStatement().executeQuery("CREATE CLASS Insertable ");
 
 		PreparedStatement statement = conn.prepareStatement("INSERT INTO Insertable ( id ) VALUES (?)");
-		statement.setString(1, "testval");
+		statement.setString( 1, "testval" );
 		int rowsInserted = statement.executeUpdate();
 
 		assertEquals( 1, rowsInserted );
@@ -74,11 +74,11 @@ public class OrientJdbcPreparedStatementTest extends OrientJdbcBaseTest {
 		conn.createStatement().executeQuery("INSERT INTO Insertable(id) VALUES(1)");
 		conn.createStatement().executeQuery("INSERT INTO Insertable(id) VALUES(2)");
 
-		PreparedStatement statement = conn.prepareStatement("DELETE FROM Insertable WHERE ID > ?");
-		statement.setInt(1, 0);
-		int rowsInserted = statement.executeUpdate();
+		PreparedStatement statement = conn.prepareStatement("DELETE FROM Insertable WHERE id > ?");
+		statement.setInt( 1, 0 );
+		int rowsDeleted = statement.executeUpdate();
 
-		assertEquals( 2, rowsInserted );
+		assertEquals( 2, rowsDeleted );
 	}
 
 	@Test

--- a/src/test/java/com/orientechnologies/orient/jdbc/OrientJdbcPreparedStatementTest.java
+++ b/src/test/java/com/orientechnologies/orient/jdbc/OrientJdbcPreparedStatementTest.java
@@ -69,6 +69,19 @@ public class OrientJdbcPreparedStatementTest extends OrientJdbcBaseTest {
 	}
 
 	@Test
+	public void testExecuteUpdateReturnsNumberOfRowsDeleted() throws Exception {
+		conn.createStatement().executeQuery("CREATE CLASS Insertable ");
+		conn.createStatement().executeQuery("INSERT INTO Insertable(id) VALUES(1)");
+		conn.createStatement().executeQuery("INSERT INTO Insertable(id) VALUES(2)");
+
+		PreparedStatement statement = conn.prepareStatement("DELETE FROM Insertable WHERE ID > ?");
+		statement.setInt(1, 0);
+		int rowsInserted = statement.executeUpdate();
+
+		assertEquals( 2, rowsInserted );
+	}
+
+	@Test
   public void shouldExecutePreparedStatement() throws Exception {
     PreparedStatement stmt = conn.prepareStatement("SELECT  " + "FROM Item " + "WHERE stringKey = ? OR intKey = ?");
     assertNotNull(stmt);


### PR DESCRIPTION
Previous PR was incorrect - the test is passing, and DELETE is working as expected - I'd overlooked the case sensitivity (now corrected)