### PR TITLE
DatabaseMetadata getColumns return all columns

### DIFF
--- a/src/main/java/com/orientechnologies/orient/jdbc/OrientJdbcDatabaseMetaData.java
+++ b/src/main/java/com/orientechnologies/orient/jdbc/OrientJdbcDatabaseMetaData.java
@@ -40,6 +40,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -136,11 +137,13 @@ public class OrientJdbcDatabaseMetaData implements DatabaseMetaData {
 
     final OClass clazz = database.getMetadata().getSchema().getClass(tableNamePattern);
     if (clazz != null) {
-      final OProperty prop = clazz.getProperty(columnNamePattern);
-      if (prop != null) {
-        records.add((ODocument) new ODocument().field("TABLE_CAT", database.getName()).field("TABLE_NAME", clazz.getName())
-            .field("COLUMN_NAME", prop.getName()).field("DATA_TYPE", OrientJdbcResultSetMetaData.getSqlType(prop.getType()))
-            .field("COLUMN_SIZE", 1).field("NULLABLE", !prop.isNotNull()).field("IS_NULLABLE", prop.isNotNull() ? "NO" : "YES"));
+      final Map<String, OProperty> propertiesMap = clazz.propertiesMap();
+      for (OProperty prop : propertiesMap.values()) {
+        if (columnNamePattern == null || columnNamePattern.equals("%") || columnNamePattern.equalsIgnoreCase(prop.getName())) {
+          records.add((ODocument) new ODocument().field("TABLE_CAT", database.getName()).field("TABLE_NAME", clazz.getName())
+              .field("COLUMN_NAME", prop.getName()).field("DATA_TYPE", OrientJdbcResultSetMetaData.getSqlType(prop.getType()))
+              .field("COLUMN_SIZE", 1).field("NULLABLE", !prop.isNotNull()).field("IS_NULLABLE", prop.isNotNull() ? "NO" : "YES"));
+        }
       }
     }
 

--- a/src/test/java/com/orientechnologies/orient/jdbc/OrientJdbcDatabaseMetaDataTest.java
+++ b/src/test/java/com/orientechnologies/orient/jdbc/OrientJdbcDatabaseMetaDataTest.java
@@ -122,7 +122,7 @@ public class OrientJdbcDatabaseMetaDataTest extends OrientJdbcBaseTest {
   }
 
   @Test
-  public void getSingleTables() throws SQLException {
+  public void getSingleTable() throws SQLException {
     ResultSet rs = this.metaData.getTables(null, null, "ouser", null);
     int tableCount = 0;
 
@@ -130,6 +130,28 @@ public class OrientJdbcDatabaseMetaDataTest extends OrientJdbcBaseTest {
       tableCount = tableCount + 1;
     }
     assertEquals(1, tableCount);
+  }
+
+  @Test
+  public void getSingleColumn() throws SQLException {
+    ResultSet rs = this.metaData.getColumns(null, null, "Article", "uuid");
+
+    int colCount = 0;
+    while (rs.next()) {
+      colCount += 1;
+    }
+    assertEquals(1, colCount);
+  }
+  
+  @Test
+  public void getAllColumns() throws SQLException {
+    ResultSet rs = this.metaData.getColumns(null, null, "Article", null);
+
+    int colCount = 0;
+    while (rs.next()) {
+      colCount += 1;
+    }
+    assertTrue(colCount > 1);
   }
 
 }


### PR DESCRIPTION
When the column pattern is null or % (now tools like DBVisualizer are able to show the columns for each table)